### PR TITLE
include 'add_dependency'

### DIFF
--- a/ruboty-fortune.gemspec
+++ b/ruboty-fortune.gemspec
@@ -39,4 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "ruboty"
   spec.add_development_dependency "nokogiri"
+
+  spec.add_dependency "ruboty"
+  spec.add_dependency "nokogiri"
 end


### PR DESCRIPTION
gemの依存関係がdevelop向けだけだったため、利用する際のGemfileの書き方が

```
gem 'nokogiri'
gem 'ruboty'
gem 'ruboty-fortune'
```

だったので、依存関係を書き込んで

```
gem 'ruboty-fortune'
```

で動くようにしてみました
